### PR TITLE
Accept scrollingDom for arbitrary nesting

### DIFF
--- a/xpull.js
+++ b/xpull.js
@@ -38,6 +38,7 @@
         defaults = {
             pullThreshold:50,
             spinnerTimeout:2000,
+            scrollingDom:null,  // if null, specified element
             callback:function(){}
         };
     function Plugin( element, options ) {
@@ -78,7 +79,7 @@
             });
             elm.unbind('touchmove.'+pluginName);
         	elm.on('touchmove.'+pluginName, function(ev){
-        		if(elm.position().top < 0 || elm.parent().scrollTop() > 0){ // trigger callback only if pulled from the top of the list
+        		if(elm.position().top < 0 || (inst.options.scrollingDom || elm.parent()).scrollTop() > 0){ // trigger callback only if pulled from the top of the list
         			return true;
         		}
                 if(inst.indicatorHidden){


### PR DESCRIPTION
In cases, the scrolling element is not the same as element that pulls-down on reload. (like #4)
For example, top item is freezed and not refreshed, but scroll like others.

By specifying the toplevel scrolling element to scrollingDom, such separation becomes possible.