### PR TITLE
Added xpull.css to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "xpull",
-  "main": "xpull.js",
+  "main": ["xpull.js","xpull.css"],
   "version": "1.0.0",
   "homepage": "https://github.com/sjovanovic/xpull",
   "authors": [


### PR DESCRIPTION
The bower spec (http://bower.io/docs/creating-packages/#bowerjson) allows for an array of "main" items.
> main  string or array: The primary acting files necessary to use your package.
So I added the css file to the main property, this will way it will be automatically linked by tools like wiredep.