### PR TITLE
Provide option to override default loading markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,14 @@ Include xpull.css and xpull.js then:
 
 ### Options:
 
-``` 
-{ 
+```
+{
     'pullThreshold':50, // Pull threshold - amount in  pixels required to pull to enable release callback
     'callback':function(){}, // triggers after user pulls the content over pull threshold and releases
     'spinnerTimeout':2000 // timeout in miliseconds after which the loading indicator stops spinning. If set to 0 - the loading will be indefinite
-}  
-``` 
+    'loadingHtml': '<div class="pull-indicator my-custom-pull-indicator"><div class="arrow-body my-custom-arrow-class"></div><div class="triangle-down"></div><div class="pull-spinner">Hold tight, reloading!</div></div>' // optional - customize the default loading markup (certain classes need to be present for it to function though: .pull-indicator, .arrow-body, .triangle-down, .pull-spinner)
+}
+```
 
  To get the instance of Xpull:
 

--- a/xpull.js
+++ b/xpull.js
@@ -20,7 +20,8 @@
  {
     'pullThreshold':50, // Pull threshold - amount in pixels after which the callback is activated
     'callback':function(){}, // triggers after user pulls the content over pull threshold
-    'spinnerTimeout':2000 // timeout in miliseconds after which the loading indicator stops spinning. If set to 0 - the loading will be indefinite
+    'spinnerTimeout':2000, // timeout in miliseconds after which the loading indicator stops spinning. If set to 0 - the loading will be indefinite
+    'loadingHtml': '<div class="pull-indicator my-custom-pull-indicator"><div class="arrow-body my-custom-arrow-class"></div><div class="triangle-down"></div><div class="pull-spinner">Hold tight, reloading!</div></div>' // optional - customize the default loading markup (certain classes need to be present for it to function though: .pull-indicator, .arrow-body, .triangle-down, .pull-spinner)
  }
 
  To get the instance of Xpull:
@@ -42,7 +43,8 @@
             scrollingDom:null,  // if null, specified element
 			onPullStart:function(){},
 			onPullEnd:function(){},
-            callback:function(){}
+            callback:function(){},
+            loadingHtml: '<div class="pull-indicator"><div class="arrow-body"></div><div class="triangle-down"></div><div class="pull-spinner"></div></div>'
         };
     function Plugin( element, options ) {
         this.element = element;
@@ -57,7 +59,7 @@
             var elm = $(inst.element).children();
             inst.elm = elm;
             elm.parent().find('.pull-indicator').remove();
-            elm.parent().prepend('<div class="pull-indicator"><div class="arrow-body"></div><div class="triangle-down"></div><div class="pull-spinner"></div></div>');
+            elm.parent().prepend(inst.options.loadingHtml);
             inst.indicator = elm.parent().find('.pull-indicator:eq(0)');
             inst.spinner = elm.parent().find('.pull-spinner:eq(0)');
             inst.arrow = elm.parent().find('.arrow-body:eq(0),.triangle-down:eq(0)');


### PR DESCRIPTION
This PR addresses issue #2

I added a new (optional) initialization option called `loadingHtml` which lets a developer customize the HTML that appears when the list is pulled down (loading spinner etc).